### PR TITLE
added argument parser and requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+forex_python

--- a/zenpal.py
+++ b/zenpal.py
@@ -2,6 +2,7 @@ import csv
 import datetime
 import sys
 import forex_python.converter
+from argparse import ArgumentParser
 
 ACCOUNT_CURR = 'USD'
 CONVERSION = 'General Currency Conversion'
@@ -102,5 +103,12 @@ def load(filename):
 
 
 if __name__ == "__main__":
-    for line in load('Download.CSV'):
+    parser = ArgumentParser()
+    parser.add_argument('-f', '--file', required=False, help='Path or name of the file you wish to edit',
+                        default='Download.CSV')
+
+    args = parser.parse_args()
+    infile = args.file
+
+    for line in load(infile):
         print("\t".join(line))


### PR DESCRIPTION
This is just a quick and dirty argument parser that needs a "-f filename" included on your cli command. This will allow you to follow the current process but specify the csv file. Or it will assume Download.CSV as the default parameter. 

I was unable to fully test this as the provided csv file does not yield results:

Traceback (most recent call last):
  File "enpal.py", line 105, in <module>
    for line in load('Download.CSV'):
  File "zenpal.py", line 54, in load
    dkey = to_unixtime(row)
  File "zenpal.py", line 20, in to_unixtime
    return int(datetime.datetime.strptime(rrow[Date] + ' ' + rrow[Time], "%d/%m/%Y %H:%M:%S").timestamp())
KeyError: '\ufeff"Date"'

However, using the argument parser it will get to the same point whether you specify a new filename with -f or not. If you can iron out that issue or provide a .csv file that works I can write an additional parameter for specifying an output file. 