### PR TITLE
CLI, prediction pipeline, and full web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config.py
 zenmoney.json
 CLAUDE.md
+serve.bat

--- a/web_review.py
+++ b/web_review.py
@@ -32,8 +32,11 @@ WINDOW_DEFAULT = {
 # ---------------------------------------------------------------------------
 app = Flask(__name__)
 
-zen       = load_or_sync(FILENAME, ZEN_API_TOKEN)
-predictor = Predictor()
+zen = load_or_sync(FILENAME, ZEN_API_TOKEN)
+try:
+    predictor = Predictor()
+except Exception:
+    predictor = None
 
 tag_map     = {t['id']: t['title'] for t in zen.tag}
 tag_id_map  = {t['title']: t['id'] for t in zen.tag}
@@ -96,6 +99,10 @@ def _reload_zen():
     tags_sorted = sorted(zen.tag, key=lambda t: t['title'])
     df_all      = pd.DataFrame(zen.transaction)
     df_all['date'] = pd.to_datetime(df_all['date'])
+    try:
+        predictor = Predictor()
+    except Exception:
+        predictor = None
     return zen
 
 
@@ -502,7 +509,7 @@ DATA_TEMPLATE = """<!doctype html><html lang="en"><head>
       <div id="prev-area" style="margin-top:12px"></div>
       <div id="push-row" class="push-row" style="display:none">
         <form method="post" action="/import/push">
-          <button class="btn btn-primary">Push to Zenmoney</button>
+          <button class="btn btn-primary">Push &amp; Predict</button>
         </form>
         <span class="push-note" id="push-note"></span>
       </div>
@@ -553,7 +560,7 @@ function doPreview() {
           h += '</table>';
         }
         area.innerHTML = h;
-        document.getElementById('push-note').textContent = data.total + ' transaction(s) ready to push';
+        document.getElementById('push-note').textContent = data.total + ' transaction(s) — will predict tags after push';
         document.getElementById('push-row').style.display = 'flex';
       }
       btn.textContent = 'Refresh'; btn.disabled = false;
@@ -784,11 +791,47 @@ def import_push():
             new_txns = get_updates(z, path, acc_id)['transaction']
             print(f'{label}: {len(new_txns)} new transaction(s)')
             all_new.extend(new_txns)
-        if all_new:
-            load_or_sync(FILENAME, ZEN_API_TOKEN, out_diff={'transaction': all_new})
-            print(f'Pushed {len(all_new)} transaction(s).')
-        else:
+        if not all_new:
             print('Nothing to import.')
+            _reload_zen()
+            return
+
+        new_ids = {t['id'] for t in all_new}
+        print(f'Pushing {len(all_new)} transaction(s)...')
+        z = load_or_sync(FILENAME, ZEN_API_TOKEN, out_diff={'transaction': all_new})
+
+        if predictor is None:
+            print('No model — transactions pushed without tags.')
+            _reload_zen()
+            return
+
+        print('Running predictions on enriched data...')
+        try:
+            local_tag_map = {t['id']: t['title'] for t in z.tag}
+            enriched = [t for t in z.transaction if t['id'] in new_ids]
+            df_new = pd.DataFrame(enriched)
+            df_new['date'] = pd.to_datetime(df_new['date'])
+            df_tagged = predictor.tag(df_new, z)
+
+            tag_updates = []
+            for row in df_tagged.to_dict('records'):
+                tag_id = row.get('final_tag')
+                tag_name = local_tag_map.get(tag_id, '(no tag)') if tag_id else '(no tag)'
+                payee = row.get('originalPayee') or row.get('payee') or ''
+                amt = row.get('outcome', 0) or 0
+                amt_s = f"-{amt:.2f}" if amt else f"+{row.get('income', 0):.2f}"
+                date_s = pd.Timestamp(row['date']).strftime('%Y-%m-%d')
+                print(f"  {date_s}  {amt_s:>10}  {payee[:38]:<38}  → {tag_name}")
+                if tag_id:
+                    tag_updates.extend(z.set_tags(row['id'], [tag_id])['transaction'])
+
+            if tag_updates:
+                load_or_sync(FILENAME, ZEN_API_TOKEN, out_diff={'transaction': tag_updates})
+                print(f'Applied tags to {len(tag_updates)}/{len(all_new)} transaction(s).')
+            else:
+                print('Predictions returned no tags.')
+        except Exception as e:
+            print(f'Warning: prediction failed ({e}), transactions pushed without tags.')
         _reload_zen()
 
     run_task(_fn)

--- a/zp.py
+++ b/zp.py
@@ -92,6 +92,7 @@ def get_updates(zen, csv_file, acc_id):
 # Import helpers
 # ---------------------------------------------------------------------------
 
+
 def detect_op_files(downloads_dir):
     """Return (date_suffix, [(path, acc_id, label), ...]) for the latest tapahtumat group."""
     try:
@@ -234,8 +235,41 @@ def cmd_import(args):
         print('Aborted.')
         return
 
-    load_or_sync(out_diff={'transaction': all_new})
-    print('Done.')
+    new_ids = {t['id'] for t in all_new}
+    print('Pushing raw transactions...')
+    zen = load_or_sync(out_diff={'transaction': all_new})
+
+    try:
+        import pandas as pd
+        from pipeline import Predictor
+        predictor = Predictor()
+        local_tag_map = {t['id']: t['title'] for t in zen.tag}
+        enriched = [t for t in zen.transaction if t['id'] in new_ids]
+        df = pd.DataFrame(enriched)
+        df['date'] = pd.to_datetime(df['date'])
+        df_tagged = predictor.tag(df, zen)
+
+        tag_updates = []
+        print()
+        for row in df_tagged.to_dict('records'):
+            tag_id = row.get('final_tag')
+            tag_name = local_tag_map.get(tag_id, '(no tag)') if tag_id else '(no tag)'
+            payee = row.get('originalPayee') or row.get('payee') or ''
+            amt = row.get('outcome', 0) or 0
+            amt_s = f"-{amt:.2f}" if amt else f"+{row.get('income', 0):.2f}"
+            date_s = pd.Timestamp(row['date']).strftime('%Y-%m-%d')
+            print(f"  {date_s}  {amt_s:>10}  {payee[:38]:<38}  → {tag_name}")
+            if tag_id:
+                tag_updates.extend(zen.set_tags(row['id'], [tag_id])['transaction'])
+
+        if tag_updates:
+            print()
+            load_or_sync(out_diff={'transaction': tag_updates})
+            print(f'Applied tags to {len(tag_updates)}/{len(all_new)} transaction(s).')
+        else:
+            print('\nNo tags to apply.')
+    except Exception as e:
+        print(f'Warning: prediction failed ({e}), transactions pushed without tags.')
 
 
 def cmd_reimport(args):


### PR DESCRIPTION
## Summary

- **`zp.py`** — single CLI replacing `main.py`, `merge_transfers.py`, `reimport.py`, `apply_review.py`. Commands: `sync`, `import` (auto-detects OP CSVs with interactive preview), `reimport`, `merge` (defaults to last 30 days), `serve` (opens browser automatically), `zen`.

- **`pipeline.py`** — two-stage prediction. `PRE_RULES` drop mislabelled training rows before fitting; `POST_RULES` override predictions after inference. `Predictor.tag(df, zen)` is the combined entry point. Rule-forced tags display at 146% confidence. First rule: Credo Bank *0686 outcomes → Onetime/others.

- **`web_review.py`** — full rewrite with three-tab layout (Review / Data / Merge). Data tab: sync, CSV import with AJAX preview, date-range reimport with confirmation. Merge tab: transfer pair candidates with auto-matched pairs pre-checked. Shared background task runner streams live print output for all long-running ops. Stop server button uses `os._exit`.

- **`train.py`** — extracted from notebook; uses `apply_pre_rules` from pipeline instead of old `filter_prediction` loop.

- **`run.ipynb`** — refactored with shared helpers (`load_transactions`, `filter_df`, `add_features`), no duplicate imports or zen loading, predict cell is now self-contained.

- **`zenmoney.py`** — `apply_diff` merges by id (no duplicate accumulation on repeated syncs), `set_tags()` helper added.

## Import workflow

OP CSV import now uses a two-pass approach so predictions run on Zenmoney-enriched data (same quality the model was trained on):

1. Parse CSVs, show raw transactions in preview
2. **Push & Predict** button: push raw transactions → sync → run predictor on enriched data → push tags
3. Task log lists each transaction with the applied tag

## Reviewer notes

- `rules.py` kept as a compatibility shim (`filter_prediction` still used in one place); can be deleted once `web_review.py` is fully migrated to `Predictor.tag()`.
- `DOWNLOADS` path is hardcoded in `zp.py` — will need parameterisation for other machines.
- `predictor` startup wrapped in `try/except` so the server starts cleanly when model files are absent.