### PR TITLE
Move model files into prediction/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ config.py
 zenmoney.json
 CLAUDE.md
 serve.bat
+prediction/model.cbm
+prediction/model_features.json
+prediction/catboost_info/
+window.json

--- a/prediction/pipeline.py
+++ b/prediction/pipeline.py
@@ -11,8 +11,8 @@ from typing import Callable, NamedTuple
 import pandas as pd
 from catboost import CatBoostClassifier
 
-MODEL_PATH    = '../model.cbm'
-FEATURES_PATH = '../model_features.json'
+MODEL_PATH    = 'prediction/model.cbm'
+FEATURES_PATH = 'prediction/model_features.json'
 
 # ---------------------------------------------------------------------------
 # Account constants

--- a/prediction/train.py
+++ b/prediction/train.py
@@ -11,8 +11,8 @@ from sklearn.metrics import classification_report
 from prediction.pipeline import MANUAL_TAGS, OP_FAMILY_ID, apply_pre_rules
 from rules import _tag_name_map
 
-MODEL_PATH      = '../model.cbm'
-FEATURES_PATH   = '../model_features.json'
+MODEL_PATH      = 'prediction/model.cbm'
+FEATURES_PATH   = 'prediction/model_features.json'
 MIN_CLASS_SAMPLES = 10
 ITERATIONS = 200
 
@@ -81,7 +81,8 @@ def train_model(zen, train_start: str, train_end: str, progress_fn=None) -> str:
 
     model = CatBoostClassifier(iterations=ITERATIONS, verbose=0,
                                cat_features=cat_features,
-                               text_features=text_features)
+                               text_features=text_features,
+                               train_dir='prediction/catboost_info')
     model.fit(X_train, y_train,
               callbacks=[_ProgressCallback(ITERATIONS, progress_fn)])
 


### PR DESCRIPTION
## Summary

Moves `model.cbm`, `model_features.json`, and `catboost_info/` from the project root into `prediction/` to keep all ML artefacts in one place.

## Changes

- `model.cbm`, `model_features.json`, `catboost_info/` → `prediction/`
- `MODEL_PATH` / `FEATURES_PATH` in `pipeline.py` and `train.py` updated from `'../model.cbm'` (was broken — pointed above the project root) to `'prediction/model.cbm'`
- `CatBoostClassifier` in `train.py` gets `train_dir='prediction/catboost_info'` so training logs stay out of the root
- `.gitignore` updated to match new paths; `window.json` added